### PR TITLE
[fix] 자유학기제/학년제 default 값 변경

### DIFF
--- a/packages/shared/src/components/StepWrapper/index.tsx
+++ b/packages/shared/src/components/StepWrapper/index.tsx
@@ -113,7 +113,7 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
     resolver: zodResolver(step4Schema),
     defaultValues: {
       liberalSystem:
-        data?.middleSchoolAchievement.liberalSystem || LiberalSystemValueEnum.FREE_GRADE,
+        data?.middleSchoolAchievement.liberalSystem || LiberalSystemValueEnum.FREE_SEMESTER,
       achievement1_1: data?.middleSchoolAchievement.achievement1_1 || undefined,
       achievement1_2: data?.middleSchoolAchievement.achievement1_2 || undefined,
       achievement2_1: data?.middleSchoolAchievement.achievement2_1 || undefined,


### PR DESCRIPTION
## 개요 💡

> 지원 학생 대부분이 `자유학년제`보다 `자유학기제`인 경우가 많아, `liberalSystem`의 기본값을 `자유학년제`에서 `자유학기제`로 변경해 달라는 요구사항이 들어와 해당 작업 진행했습니다.
