### PR TITLE
[feat] 예체능 점수 알파벳으로 변환하여 표시

### DIFF
--- a/apps/client/src/components/PrintPage/ArtsPhysicalTable/index.tsx
+++ b/apps/client/src/components/PrintPage/ArtsPhysicalTable/index.tsx
@@ -1,6 +1,6 @@
 import { OneseoStatusType } from 'types';
 
-import { getArtPhysicalScores, semesterArray } from 'client/utils';
+import { getArtPhysicalScores, scoreToAlphabet, semesterArray } from 'client/utils';
 
 import { ARTS_PHYSICAL_SUBJECTS } from 'shared/constants';
 import { cn } from 'shared/lib/utils';
@@ -99,7 +99,7 @@ const ArtsPhysicalTable = ({ oneseo }: OneseoStatusType) => {
               const score = artPhysicalScores[actualColIdx]?.[rowIdx];
               return (
                 <td key={`score-${colIdx}-${rowIdx}`} className={cn('border', 'border-black')}>
-                  {score ?? ''}
+                  {scoreToAlphabet[score ?? -1] || ''}
                 </td>
               );
             })}


### PR DESCRIPTION
## 개요 💡

> 예체능 성취도(A, B, C, 없음)로 표시하는 작업 완료했습니다.

## 화면
**[기존]**
<img width="769" height="474" alt="image" src="https://github.com/user-attachments/assets/60f972eb-c99e-4a3e-91d7-f28a19bc415c" />

**[변경 후]**
<img width="643" height="432" alt="image" src="https://github.com/user-attachments/assets/5eafb77e-834a-4ae1-9a6b-1022828acce7" />

