### PR TITLE
[fix] '성취도/평어' 텍스트를 '성취도'로 수정

### DIFF
--- a/apps/client/src/components/PrintPage/ArtsPhysicalTable/index.tsx
+++ b/apps/client/src/components/PrintPage/ArtsPhysicalTable/index.tsx
@@ -59,7 +59,7 @@ const ArtsPhysicalTable = ({ oneseo }: OneseoStatusType) => {
                 'font-bold',
               )}
             >
-              성취도/평어
+              성취도
             </th>
           ))}
         </tr>

--- a/apps/client/src/components/PrintPage/GeneralSubjectsTable/index.tsx
+++ b/apps/client/src/components/PrintPage/GeneralSubjectsTable/index.tsx
@@ -52,7 +52,7 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
                 'font-bold',
               )}
             >
-              성취도/평어
+              성취도
             </div>
           </div>
           {!oneseo.calculatedScore.generalSubjectsScoreDetail.score1_1 ? (
@@ -115,7 +115,7 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
                 'font-bold',
               )}
             >
-              성취도/평어
+              성취도
             </div>
           </div>
           {!oneseo.calculatedScore.generalSubjectsScoreDetail.score1_2 ? (
@@ -177,7 +177,7 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
               'font-bold',
             )}
           >
-            성취도/평어
+            성취도
           </div>
         </div>
         {!oneseo.calculatedScore.generalSubjectsScoreDetail.score2_1 ? (
@@ -226,7 +226,7 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
               'font-bold',
             )}
           >
-            성취도/평어
+            성취도
           </div>
         </div>
         {!oneseo.calculatedScore.generalSubjectsScoreDetail.score2_2 ? (
@@ -283,7 +283,7 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
               'font-bold',
             )}
           >
-            성취도/평어
+            성취도
           </div>
         </div>
         {!oneseo.calculatedScore.generalSubjectsScoreDetail.score3_1 ? (
@@ -333,7 +333,7 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
                 'font-bold',
               )}
             >
-              성취도/평어
+              성취도
             </div>
           </div>
           {!oneseo.calculatedScore.generalSubjectsScoreDetail.score3_2 ? (


### PR DESCRIPTION
## 개요 💡

>  '성취도/평어' 텍스트를 '성취도'로 수정하였습니다.

## 화면
<img width="455" height="327" alt="image" src="https://github.com/user-attachments/assets/619616f3-7292-41c9-a0b0-e972be2d0a00" />
