### PR TITLE
[feat] 추가 과목 중복 방지

### DIFF
--- a/packages/shared/src/schemas/step4Schema.ts
+++ b/packages/shared/src/schemas/step4Schema.ts
@@ -11,6 +11,8 @@ import {
 } from 'shared/constants';
 import { getValuesByEnum } from 'shared/utils';
 
+const FORBIDDEN_SUBJECTS: string[] = [...ARTS_PHYSICAL_SUBJECTS, ...GENERAL_SUBJECTS];
+
 const achievementSchema = (minLength: number) =>
   z.nullable(
     z.array(z.number().refine((value) => MAX_SCORE >= value && value >= MIN_SCORE)).min(minLength),
@@ -27,7 +29,16 @@ export const step4Schema = z
     achievement2_2: achievementSchema(GENERAL_SUBJECTS.length),
     achievement3_1: achievementSchema(GENERAL_SUBJECTS.length),
     achievement3_2: achievementSchema(GENERAL_SUBJECTS.length),
-    newSubjects: z.optional(z.array(z.string().min(1))),
+    newSubjects: z.optional(
+      z
+        .array(z.string().min(1))
+        .refine((items) => new Set(items).size === items.length, {
+          message: '과목이 중복되어 작성되어 있습니다.',
+        })
+        .refine((items) => items.every((item) => !FORBIDDEN_SUBJECTS.includes(item)), {
+          message: '기본 과목이 작성되어 있습니다.',
+        }),
+    ),
     artsPhysicalAchievement: achievementSchema(ARTS_PHYSICAL_SUBJECTS.length * 3),
     absentDays: nonSubjectSchema,
     attendanceDays: nonSubjectSchema,


### PR DESCRIPTION
## 개요 💡

추가 과목 중복 문제를 방지할수 있도록 zod schema를 수정하였습니다

## 작업내용 ⌨️

- zod schema 수정

## 관련 issue 🤯

사용자가 원서를 작성하면서 추가 과목 이름이 중복이 되는 경우에는 진짜로 중복이 된지 모르는 상황 밖에 없다고 생각이 드는데 피드백이 없이 단순히 버튼 비활성화가 된다면 사용자 경험이 떨어질것 같다고 생각합니다.
하지만 현재 원서 작성 기능은 입력값이 입력되야지만 다음, 제출 버튼이 활성화 되는 식이라 버튼을 눌렀을때 alert, toast로 피드백을 줄수 있는 상황이 아닙니다. 이 부분을 개선할수 있는 방법을 고민해보면 좋을것 같습니다
