### PR TITLE
[fix] 모집 안내 연도 수정

### DIFF
--- a/apps/client/src/components/MainPage/Section2/index.tsx
+++ b/apps/client/src/components/MainPage/Section2/index.tsx
@@ -9,7 +9,6 @@ import {
   Section2Icon6,
 } from 'client/assets';
 
-import { NEXT_YEAR } from 'shared/constants';
 import { cn } from 'shared/lib/utils';
 
 const stepsData = [
@@ -124,7 +123,7 @@ const Section2 = () => {
           >
             광주소프트웨어마이스터고등학교
             <br />
-            {NEXT_YEAR} 신입생 모집절차
+            2026 신입생 모집절차
           </h1>
           <p
             className={cn(

--- a/apps/client/src/components/MainPage/Section3/index.tsx
+++ b/apps/client/src/components/MainPage/Section3/index.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import * as I from 'client/assets';
 import { RECRUITMENT_PERIOD } from 'client/constants';
 
-import { NEXT_YEAR } from 'shared/constants';
 import { cn } from 'shared/lib/utils';
 
 const buttonStyle = [
@@ -55,7 +54,7 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
           >
             광주소프트웨어마이스터고등학교
             <br />
-            {NEXT_YEAR} 신입생 모집
+            2026 신입생 모집
           </h1>
           <p className={cn('mb-0', 'lg:mb-8', 'mt-[1rem]', 'hidden', 'smx:flex', 'text-gray-500')}>
             접수 기간: {RECRUITMENT_PERIOD.startDate} ~ {RECRUITMENT_PERIOD.endDate}


### PR DESCRIPTION
## 개요 💡

> https://github.com/themoment-team/hellogsm-front-25/pull/277 해당 pr 에서 승재 선배님께서 말씀해주신 것처럼 
2026년 1월에 아직 2027년도 모집 계획이 fix되지 않았을 때 `NEXT_YAER`을 사용하여 보여준다면, 사용자에게 혼란을 줄 것 같아 
이를 없애기 위해 `NEXT_YAER` 을 사용하는 것이 아닌 `2026`으로 재변경하였습니다


