### PR TITLE
[fix] AlertDialog 버튼 간헐적 클릭 문제 해결

### DIFF
--- a/apps/client/src/pageContainer/CalculatePage/index.tsx
+++ b/apps/client/src/pageContainer/CalculatePage/index.tsx
@@ -121,7 +121,7 @@ const CalculatePage = ({ isServerHealthy }: CalculateProps) => {
             <AlertDialogTitle>모의 성적 계산은 10월 13일부터 가능합니다.</AlertDialogTitle>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogAction>
+            <AlertDialogAction asChild>
               <Link href={'/'}>확인</Link>
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/apps/client/src/pageContainer/CheckResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckResultPage/index.tsx
@@ -100,12 +100,10 @@ const CheckResultPage = ({
             </AlertDialogTitle>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogAction
-              onClick={() => {
-                setShowModal(false);
-              }}
-            >
-              <Link href={prevUrl}>확인</Link>
+            <AlertDialogAction asChild>
+              <Link href={prevUrl} onClick={() => setShowModal(false)}>
+                확인
+              </Link>
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## 개요 💡

모의 성적 계산에서 팝업 버튼이 간헐적으로 클릭되지 않던 이슈 해결했습니다

## 작업내용 ⌨️

- asChild 프롭 사용하여 모의 성적 계산에서 팝업 버튼이 간헐적으로 클릭되지 않던 이슈 해결