### PR TITLE
[fix] 회원가입 성공 시 리디렉션 방식 변경

### DIFF
--- a/apps/client/src/pageContainer/SignUpPage/index.tsx
+++ b/apps/client/src/pageContainer/SignUpPage/index.tsx
@@ -475,7 +475,7 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
             <AlertDialogAction
               onClick={() => {
                 setShowModal('');
-                if (showModal === 'success') push('/');
+                if (showModal === 'success') window.location.href = '/';
               }}
             >
               확인


### PR DESCRIPTION
## 개요 💡

정확한 원인은 아직 찾지 못했지만, Next.js의 라우터 캐시 기능이 동작하는 것으로 추정됩니다. 이로 인해 회원가입 후 메인 페이지로 리다이렉트할 때 getMyAuthInfo, getMyMemberInfo 쿼리를 무효화하더라도 회원가입 전의 헤더 상태(‘회원가입을 진행해주세요’)가 그대로 표시되었습니다. 따라서 클라이언트 사이드 네비게이션 대신 페이지를 완전히 새로고침하여 서버에서 최신 데이터를 강제로 받아오는 방식으로 변경했습니다.

## 작업내용 ⌨️

- router.push 대신 window.location.href를 사용하여 페이지를 완전히 새로고침하도록 수정

## 관련 issue 🤯

현재로서는 이 방법 외에 마땅한 대안을 찾지 못했는데, 혹시 다른 해결책을 알고 계신 분이 있다면 코멘트 부탁드립니다.