### PR TITLE
[feat] 일반 교과 과목 추가 및 순서 변경

### DIFF
--- a/packages/shared/src/constants/subject.ts
+++ b/packages/shared/src/constants/subject.ts
@@ -2,11 +2,12 @@ export const ARTS_PHYSICAL_SUBJECTS = ['체육', '음악', '미술'] as const;
 
 export const GENERAL_SUBJECTS = [
   '국어',
-  '도덕',
   '사회',
+  '도덕',
   '역사',
   '수학',
   '과학',
   '기술가정',
+  '정보',
   '영어',
 ] as const;


### PR DESCRIPTION
## 개요 💡

일반 교과 과목에 '정보'를 추가하고 입학전형요강에 있는 원서 양식에 맞게 과목 순서를 변경 했습니다.

## 작업내용 ⌨️

- 일반 교과 과목에 '정보'를 추가
- 입학전형요강에 있는 원서 양식에 맞게 과목 순서 변경