### PR TITLE
[fix] 검정고시 지원자 잘못된 점수 표시 수정

### DIFF
--- a/apps/client/src/components/OneseoStatus/index.tsx
+++ b/apps/client/src/components/OneseoStatus/index.tsx
@@ -191,7 +191,7 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
           )}
           <td className={cn('border', 'border-black')}>
             {oneseo.privacyDetail.graduationType === 'GED'
-              ? oneseo.middleSchoolAchievement.gedAvgScore
+              ? oneseo.calculatedScore.totalSubjectsScore
               : parseFloat(
                   (
                     oneseo.calculatedScore.generalSubjectsScore! +
@@ -234,9 +234,7 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
             {oneseo.calculatedScore.volunteerScore}
           </td>
           <td className={cn('border', 'border-black')}>
-            {oneseo.privacyDetail.graduationType === 'GED'
-              ? 600
-              : oneseo.calculatedScore.attendanceScore + oneseo.calculatedScore.volunteerScore}
+            {oneseo.calculatedScore.attendanceScore + oneseo.calculatedScore.volunteerScore}
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
## 개요 💡

검정고시 지원자의 원서에서 교과성적 소계, 비교과 성적 소계가 잘 못 표기되던 문제 해결했습니다.

## 작업내용 ⌨️

- 교과성적 소계, 비교과 성적 소계가 잘 못 표기되던 문제 해결