### PR TITLE
[fix] 원서 지역명 라벨 텍스트 수정

### DIFF
--- a/apps/client/src/components/OneseoStatus/index.tsx
+++ b/apps/client/src/components/OneseoStatus/index.tsx
@@ -88,7 +88,7 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
               'font-medium',
             )}
           >
-            지역명
+            주소
           </td>
           {oneseo.privacyDetail.graduationType === 'GED' ? (
             <td colSpan={7} className={cn('border', 'border-black', 'bg-slash')} />


### PR DESCRIPTION
## 개요 💡

선생님 요구사항대로 원서에서 '지역명' 라벨 텍스트를 '주소'로 변경했습니다.

## 작업내용 ⌨️

원서에서 '지역명' 라벨 텍스트를 '주소'로 변경