### PR TITLE
[fix] 검정고시 평균 점수 표시

### DIFF
--- a/apps/client/src/components/PrintPage/OneseoStatus/index.tsx
+++ b/apps/client/src/components/PrintPage/OneseoStatus/index.tsx
@@ -99,7 +99,7 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
               {label}
             </td>
           ))}
-          <td className={cn(thStyle)}>{isGED ? '환산점' : '소계'}</td>
+          <td className={cn(thStyle)}>소계</td>
           <td className={cn(thStyle)} rowSpan={2}>
             합계 (환산총점)
           </td>

--- a/apps/client/src/components/PrintPage/OneseoStatus/index.tsx
+++ b/apps/client/src/components/PrintPage/OneseoStatus/index.tsx
@@ -23,7 +23,6 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
   } = oneseo.calculatedScore;
 
   const isGED = graduationType === 'GED';
-  const isGEDScore = !!oneseo.middleSchoolAchievement.gedAvgScore;
 
   const [year, month] = graduationDate.split('-');
 
@@ -95,37 +94,38 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
           <td className={cn(thStyle)} rowSpan={2} style={{ width: '10%' }}>
             교과 <br /> 성적
           </td>
-          {['1-1', '1-2', '2-1', '2-2', '3-1', '3-2', '예체능', '소계'].map((label) => (
-            <td key={label} className={cn(thStyle)}>
+          {['1-1', '1-2', '2-1', '2-2', '3-1', '3-2', '예체능'].map((label) => (
+            <td key={label} className={cn(thStyle, 'w-[3rem]')}>
               {label}
             </td>
           ))}
+          <td className={cn(thStyle)}>{isGED ? '환산점' : '소계'}</td>
           <td className={cn(thStyle)} rowSpan={2}>
             합계 (환산총점)
           </td>
         </tr>
         <tr>
-          {achievementGradeValues.map((gradeKey) =>
-            isGEDScore || !oneseo.middleSchoolAchievement[gradeKey]?.length ? (
-              <td
-                key={gradeKey}
-                className={cn(tdStyle, 'bg-slash', 'bg-contain', 'bg-no-repeat', 'w-[2.6875rem]')}
-              />
-            ) : (
-              <td key={gradeKey} className={cn(tdStyle)}>
-                {generalSubjectsScoreDetail[achievementScoreMap[gradeKey]]}
-              </td>
-            ),
+          {isGED ? (
+            <td className={cn(tdStyle)} colSpan={achievementGradeValues.length + 1}>
+              {oneseo.middleSchoolAchievement.gedAvgScore}
+            </td>
+          ) : (
+            <>
+              {achievementGradeValues.map((gradeKey) =>
+                !oneseo.middleSchoolAchievement[gradeKey]?.length ? (
+                  <td
+                    key={gradeKey}
+                    className={cn(tdStyle, 'bg-slash', 'bg-contain', 'bg-no-repeat')}
+                  />
+                ) : (
+                  <td key={gradeKey} className={cn(tdStyle)}>
+                    {generalSubjectsScoreDetail[achievementScoreMap[gradeKey]]}
+                  </td>
+                ),
+              )}
+              <td className={cn(tdStyle)}>{artsPhysicalSubjectsScore}</td>
+            </>
           )}
-          <td
-            className={cn(
-              tdStyle,
-              isGED && ['bg-slash', 'bg-contain', 'bg-no-repeat'],
-              'w-[2.6875rem]',
-            )}
-          >
-            {!isGED && artsPhysicalSubjectsScore}
-          </td>
           <td className={cn(tdStyle)}>
             {isGED
               ? totalSubjectsScore


### PR DESCRIPTION
## 개요 💡

> 교과성적 테이블에 검정고시 평균 점수 표시 작업했습니다.

## 작업내용 ⌨️

- 검정고시 평균 점수 표시
- ~~검정고시일 경우, `소계` -> `환산점` 으로 표기~~
- 성적 셀 너비 통일(3rem)

## 화면
**[변경 전]**
<img width="442" height="79" alt="image" src="https://github.com/user-attachments/assets/a6cd43a4-2091-43b3-bab0-244a944ee333" />

**[변경 후]**
<img width="442" height="79" alt="image" src="https://github.com/user-attachments/assets/c641c86f-f733-4f53-9f7e-1bd790839e12" />
