### PR TITLE
[fix] firefox 숫자 입력 필드 스피너 제거

### DIFF
--- a/packages/shared/src/styles/globals.css
+++ b/packages/shared/src/styles/globals.css
@@ -90,6 +90,10 @@ input[type='number']::-webkit-inner-spin-button {
   margin: 0;
 }
 
+input[type='number'] {
+  -moz-appearance: textfield;
+}
+
 body,
 * {
   box-sizing: border-box;


### PR DESCRIPTION
## 개요 💡

firefox 숫자 입력 필드 스피너 제거했습니다.

## 작업내용 ⌨️

- firefox 숫자 입력 필드 스피너 제거