### PR TITLE
[fix] CalculatePage defaultValues.liberalSystem을 FREE_SEMESTER로 변경

### DIFF
--- a/apps/client/src/pageContainer/CalculatePage/index.tsx
+++ b/apps/client/src/pageContainer/CalculatePage/index.tsx
@@ -48,7 +48,7 @@ const CalculatePage = ({ isServerHealthy }: CalculateProps) => {
   const step4UseForm = useForm<Step4FormType>({
     resolver: zodResolver(step4Schema),
     defaultValues: {
-      liberalSystem: LiberalSystemValueEnum.FREE_GRADE,
+      liberalSystem: LiberalSystemValueEnum.FREE_SEMESTER,
       freeSemester: null,
     },
   });


### PR DESCRIPTION
## 개요 💡

> 이전 PR #296 에서 누락된 `CalculatePage`에서 `defaultValues.liberalSystem`을 `자유학기제(FREE_SEMESTER)`로 변경하였습니다.