### PR TITLE
[refactor] CI/CD 시 환경변수 주입 리팩터링

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -124,24 +124,24 @@ jobs:
             docker image prune -a -f
             EOF
 
-      - name: Success Discord Notification
-        uses: sarisia/actions-status-discord@v1.11.0
-        if: success()
-        with:
-          webhook: ${{ secrets.WEBHOOK_URL }}
-          title: '✅ hello-gsm prod CD'
-          status: ${{ job.status }}
-          content: '배포가 성공적으로 완료되었습니다.'
-          username: hello-gsm bot
-          color: 4CAF50
-
-      - name: Failure notification to discord
-        uses: sarisia/actions-status-discord@v1.11.0
-        if: failure()
-        with:
-          webhook: ${{ secrets.WEBHOOK_URL }}
-          title: '❌ hello-gsm prod CD'
-          content: '배포 중 에러가 발생했습니다.'
-          status: ${{ job.status }}
-          username: hello-gsm bot
-          color: e74c3c
+#      - name: Success Discord Notification
+#        uses: sarisia/actions-status-discord@v1.11.0
+#        if: success()
+#        with:
+#          webhook: ${{ secrets.WEBHOOK_URL }}
+#          title: '✅ hello-gsm prod CD'
+#          status: ${{ job.status }}
+#          content: '배포가 성공적으로 완료되었습니다.'
+#          username: hello-gsm bot
+#          color: 4CAF50
+#
+#      - name: Failure notification to discord
+#        uses: sarisia/actions-status-discord@v1.11.0
+#        if: failure()
+#        with:
+#          webhook: ${{ secrets.WEBHOOK_URL }}
+#          title: '❌ hello-gsm prod CD'
+#          content: '배포 중 에러가 발생했습니다.'
+#          status: ${{ job.status }}
+#          username: hello-gsm bot
+#          color: e74c3c

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -3,7 +3,7 @@ name: hello-gsm-prod-cd
 on:
   push:
     branches:
-    - main
+      - main
   workflow_dispatch:
 
 jobs:
@@ -21,14 +21,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Create .env for build
+      - name: Create .env files for build
         run: |
-          cat > .env << EOF
-          ${{ secrets.PROD_ENV_FILE }}
+          cat > .env.client << EOF
+          ${{ secrets.PROD_CLIENT_ENV_FILE }}
+          EOF
+          cat > .env.admin << EOF
+          ${{ secrets.PROD_ADMIN_ENV_FILE }}
           EOF
 
       - name: All Package Build
-        run: pnpm build
+        run: |
+          cp .env.client apps/client/.env
+          cp .env.admin apps/admin/.env
+          pnpm build
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
@@ -43,7 +49,7 @@ jobs:
       - name: Docker Client build
         run: |
           docker build \
-          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
+          $(cat .env.client | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./client.Dockerfile \
           -t ${{ secrets.AWS_ECR_PROD_CLIENT_REPOSITORY }}:latest \
           .
@@ -51,7 +57,7 @@ jobs:
       - name: Docker Admin build
         run: |
           docker build \
-          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
+          $(cat .env.admin | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./admin.Dockerfile \
           -t ${{ secrets.AWS_ECR_PROD_ADMIN_REPOSITORY }}:latest \
           .
@@ -90,13 +96,13 @@ jobs:
               OLD_PORT=3001
             fi
 
-            cat > .env.prod << 'ENVEOF'
-            ${{ secrets.PROD_ENV_FILE }}
+            cat > .env.client.prod << 'ENVEOF'
+            ${{ secrets.PROD_CLIENT_ENV_FILE }}
             ENVEOF
 
             docker run -d --name hello-gsm-client-$NEW_COLOR \
               -p $NEW_PORT:3000 \
-              --env-file .env.prod \
+              --env-file .env.client.prod \
               ${{ secrets.AWS_ECR_PROD_CLIENT_REPOSITORY }}:latest
 
             docker stop hello-gsm-client-$OLD_COLOR || true
@@ -114,9 +120,13 @@ jobs:
               OLD_PORT=3003
             fi
 
+            cat > .env.admin.prod << 'ENVEOF'
+            ${{ secrets.PROD_ADMIN_ENV_FILE }}
+            ENVEOF
+
             docker run -d --name hello-gsm-admin-$NEW_COLOR \
               -p $NEW_PORT:3000 \
-              --env-file .env.prod \
+              --env-file .env.admin.prod \
               ${{ secrets.AWS_ECR_PROD_ADMIN_REPOSITORY }}:latest
 
             docker stop hello-gsm-admin-$OLD_COLOR || true

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -2,7 +2,8 @@ name: hello-gsm-prod-cd
 
 on:
   push:
-    branches: main
+    branches:
+    - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -8,39 +8,29 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }}
-      NEXT_PUBLIC_CHANNEL_IO_KEY: ${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }}
-      NEXT_PUBLIC_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_IMAGE_URL }}
-      NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF: ${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }}
-      NEXT_PUBLIC_NEIS_API_KEY: ${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }}
-      NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID: ${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }}
-      NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID: ${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }}
-      NEXT_PUBLIC_NOTION_SECRET_API_KEY: ${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }}
-      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-      NEXT_PUBLIC_KAKAO_REST_API_KEY: ${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }}
-      NEXT_PUBLIC_CDN_URL: ${{ secrets.NEXT_PUBLIC_CDN_URL }}
-      NEXT_PUBLIC_MOCK_SCORE_URL: ${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }}
-      NEXT_PUBLIC_MOCK_SCORE_API_KEY: ${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }}
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9.4.0
 
       - name: Install dependencies
         run: pnpm install
 
-      - name: All Package Build
+      - name: Create .env for build
         run: |
-          pnpm build
+          cat > .env << EOF
+          ${{ secrets.PROD_ENV_FILE }}
+          EOF
+
+      - name: All Package Build
+        run: pnpm build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -52,19 +42,7 @@ jobs:
       - name: Docker Client build
         run: |
           docker build \
-          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }} \
-          --build-arg NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
-          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-          --build-arg NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF=${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }} \
-          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-          --build-arg NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }} \
-          --build-arg NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }} \
-          --build-arg NEXT_PUBLIC_NOTION_SECRET_API_KEY=${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }} \
-          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-          --build-arg NEXT_PUBLIC_KAKAO_REST_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }} \
-          --build-arg NEXT_PUBLIC_CDN_URL=${{ secrets.NEXT_PUBLIC_CDN_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./client.Dockerfile \
           -t ${{ secrets.AWS_ECR_PROD_CLIENT_REPOSITORY }}:latest \
           .
@@ -72,12 +50,7 @@ jobs:
       - name: Docker Admin build
         run: |
           docker build \
-          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }} \
-          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./admin.Dockerfile \
           -t ${{ secrets.AWS_ECR_PROD_ADMIN_REPOSITORY }}:latest \
           .
@@ -116,21 +89,13 @@ jobs:
               OLD_PORT=3001
             fi
 
+            cat > .env.prod << 'ENVEOF'
+            ${{ secrets.PROD_ENV_FILE }}
+            ENVEOF
+
             docker run -d --name hello-gsm-client-$NEW_COLOR \
               -p $NEW_PORT:3000 \
-              -e NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }} \
-              -e NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
-              -e NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-              -e NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF=${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }} \
-              -e NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-              -e NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }} \
-              -e NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }} \
-              -e NEXT_PUBLIC_NOTION_SECRET_API_KEY=${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }} \
-              -e NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-              -e NEXT_PUBLIC_KAKAO_REST_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }} \
-              -e NEXT_PUBLIC_CDN_URL=${{ secrets.NEXT_PUBLIC_CDN_URL }} \
-              -e NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-              -e NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+              --env-file .env.prod \
               ${{ secrets.AWS_ECR_PROD_CLIENT_REPOSITORY }}:latest
 
             docker stop hello-gsm-client-$OLD_COLOR || true
@@ -150,12 +115,7 @@ jobs:
 
             docker run -d --name hello-gsm-admin-$NEW_COLOR \
               -p $NEW_PORT:3000 \
-              -e NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }} \
-              -e NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-              -e NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-              -e NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-              -e NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-              -e NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+              --env-file .env.prod \
               ${{ secrets.AWS_ECR_PROD_ADMIN_REPOSITORY }}:latest
 
             docker stop hello-gsm-admin-$OLD_COLOR || true

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -135,24 +135,24 @@ jobs:
             docker image prune -a -f
             EOF
 
-#      - name: Success Discord Notification
-#        uses: sarisia/actions-status-discord@v1.11.0
-#        if: success()
-#        with:
-#          webhook: ${{ secrets.WEBHOOK_URL }}
-#          title: '✅ hello-gsm prod CD'
-#          status: ${{ job.status }}
-#          content: '배포가 성공적으로 완료되었습니다.'
-#          username: hello-gsm bot
-#          color: 4CAF50
-#
-#      - name: Failure notification to discord
-#        uses: sarisia/actions-status-discord@v1.11.0
-#        if: failure()
-#        with:
-#          webhook: ${{ secrets.WEBHOOK_URL }}
-#          title: '❌ hello-gsm prod CD'
-#          content: '배포 중 에러가 발생했습니다.'
-#          status: ${{ job.status }}
-#          username: hello-gsm bot
-#          color: e74c3c
+      - name: Success Discord Notification
+        uses: sarisia/actions-status-discord@v1.11.0
+        if: success()
+        with:
+          webhook: ${{ secrets.WEBHOOK_URL }}
+          title: '✅ hello-gsm prod CD'
+          status: ${{ job.status }}
+          content: '배포가 성공적으로 완료되었습니다.'
+          username: hello-gsm bot
+          color: 4CAF50
+
+      - name: Failure notification to discord
+        uses: sarisia/actions-status-discord@v1.11.0
+        if: failure()
+        with:
+          webhook: ${{ secrets.WEBHOOK_URL }}
+          title: '❌ hello-gsm prod CD'
+          content: '배포 중 에러가 발생했습니다.'
+          status: ${{ job.status }}
+          username: hello-gsm bot
+          color: e74c3c

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -45,24 +45,24 @@ jobs:
           -t hello-prod-admin:latest \
           .
 
-      - name: Success Discord Notification
-        uses: sarisia/actions-status-discord@v1.11.0
-        if: success()
-        with:
-          webhook: ${{ secrets.WEBHOOK_URL }}
-          title: '✅ hello-gsm prod CI'
-          status: ${{ job.status }}
-          content: 'PR을 확인해주세요.'
-          username: hello-gsm bot
-          color: 4CAF50
-
-      - name: Failure notification to discord
-        uses: sarisia/actions-status-discord@v1.11.0
-        if: failure()
-        with:
-          webhook: ${{ secrets.WEBHOOK_URL }}
-          title: '❌ hello-gsm prod CI'
-          content: '에러를 확인해주세요.'
-          status: ${{ job.status }}
-          username: hello-gsm bot
-          color: e74c3c
+#      - name: Success Discord Notification
+#        uses: sarisia/actions-status-discord@v1.11.0
+#        if: success()
+#        with:
+#          webhook: ${{ secrets.WEBHOOK_URL }}
+#          title: '✅ hello-gsm prod CI'
+#          status: ${{ job.status }}
+#          content: 'PR을 확인해주세요.'
+#          username: hello-gsm bot
+#          color: 4CAF50
+#
+#      - name: Failure notification to discord
+#        uses: sarisia/actions-status-discord@v1.11.0
+#        if: failure()
+#        with:
+#          webhook: ${{ secrets.WEBHOOK_URL }}
+#          title: '❌ hello-gsm prod CI'
+#          content: '에러를 확인해주세요.'
+#          status: ${{ job.status }}
+#          username: hello-gsm bot
+#          color: e74c3c

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -8,53 +8,31 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }}
-      NEXT_PUBLIC_CHANNEL_IO_KEY: ${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }}
-      NEXT_PUBLIC_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_IMAGE_URL }}
-      NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF: ${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }}
-      NEXT_PUBLIC_NEIS_API_KEY: ${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }}
-      NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID: ${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }}
-      NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID: ${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }}
-      NEXT_PUBLIC_NOTION_SECRET_API_KEY: ${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }}
-      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-      NEXT_PUBLIC_KAKAO_REST_API_KEY: ${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }}
-      NEXT_PUBLIC_CDN_URL: ${{ secrets.NEXT_PUBLIC_CDN_URL }}
-      NEXT_PUBLIC_MOCK_SCORE_URL: ${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }}
-      NEXT_PUBLIC_MOCK_SCORE_API_KEY: ${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }}
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9.4.0
 
       - name: Install dependencies
         run: pnpm install
 
-      - name: All Package Build
+      - name: Create .env for build
         run: |
-          pnpm build
+          cat > .env << EOF
+          ${{ secrets.PROD_ENV_FILE }}
+          EOF
+
+      - name: All Package Build
+        run: pnpm build
 
       - name: Docker Client build
         run: |
           docker build \
-          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }} \
-          --build-arg NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
-          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-          --build-arg NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF=${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }} \
-          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-          --build-arg NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }} \
-          --build-arg NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }} \
-          --build-arg NEXT_PUBLIC_NOTION_SECRET_API_KEY=${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }} \
-          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-          --build-arg NEXT_PUBLIC_KAKAO_REST_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }} \
-          --build-arg NEXT_PUBLIC_CDN_URL=${{ secrets.NEXT_PUBLIC_CDN_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./client.Dockerfile \
           -t hello-prod-client:latest \
           .
@@ -62,12 +40,7 @@ jobs:
       - name: Docker Admin build
         run: |
           docker build \
-          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }} \
-          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./admin.Dockerfile \
           -t hello-prod-admin:latest \
           .

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -52,24 +52,24 @@ jobs:
           -t hello-prod-admin:latest \
           .
 
-#      - name: Success Discord Notification
-#        uses: sarisia/actions-status-discord@v1.11.0
-#        if: success()
-#        with:
-#          webhook: ${{ secrets.WEBHOOK_URL }}
-#          title: '✅ hello-gsm prod CI'
-#          status: ${{ job.status }}
-#          content: 'PR을 확인해주세요.'
-#          username: hello-gsm bot
-#          color: 4CAF50
-#
-#      - name: Failure notification to discord
-#        uses: sarisia/actions-status-discord@v1.11.0
-#        if: failure()
-#        with:
-#          webhook: ${{ secrets.WEBHOOK_URL }}
-#          title: '❌ hello-gsm prod CI'
-#          content: '에러를 확인해주세요.'
-#          status: ${{ job.status }}
-#          username: hello-gsm bot
-#          color: e74c3c
+      - name: Success Discord Notification
+        uses: sarisia/actions-status-discord@v1.11.0
+        if: success()
+        with:
+          webhook: ${{ secrets.WEBHOOK_URL }}
+          title: '✅ hello-gsm prod CI'
+          status: ${{ job.status }}
+          content: 'PR을 확인해주세요.'
+          username: hello-gsm bot
+          color: 4CAF50
+
+      - name: Failure notification to discord
+        uses: sarisia/actions-status-discord@v1.11.0
+        if: failure()
+        with:
+          webhook: ${{ secrets.WEBHOOK_URL }}
+          title: '❌ hello-gsm prod CI'
+          content: '에러를 확인해주세요.'
+          status: ${{ job.status }}
+          username: hello-gsm bot
+          color: e74c3c

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -21,19 +21,25 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Create .env for build
+      - name: Create .env files for build
         run: |
-          cat > .env << EOF
-          ${{ secrets.PROD_ENV_FILE }}
+          cat > .env.client << EOF
+          ${{ secrets.PROD_CLIENT_ENV_FILE }}
+          EOF
+          cat > .env.admin << EOF
+          ${{ secrets.PROD_ADMIN_ENV_FILE }}
           EOF
 
       - name: All Package Build
-        run: pnpm build
+        run: |
+          cp .env.client apps/client/.env
+          cp .env.admin apps/admin/.env
+          pnpm build
 
       - name: Docker Client build
         run: |
           docker build \
-          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
+          $(cat .env.client | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./client.Dockerfile \
           -t hello-prod-client:latest \
           .
@@ -41,7 +47,7 @@ jobs:
       - name: Docker Admin build
         run: |
           docker build \
-          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
+          $(cat .env.admin | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./admin.Dockerfile \
           -t hello-prod-admin:latest \
           .

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -2,7 +2,8 @@ name: hello-gsm-prod-ci
 
 on:
   pull_request:
-    branches: main
+    branches:
+    - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stage-cd.yml
+++ b/.github/workflows/stage-cd.yml
@@ -8,40 +8,29 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_STAGE: ${{ secrets.NEXT_PUBLIC_STAGE }}
-      NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }}
-      NEXT_PUBLIC_CHANNEL_IO_KEY: ${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }}
-      NEXT_PUBLIC_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_IMAGE_URL }}
-      NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF: ${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }}
-      NEXT_PUBLIC_NEIS_API_KEY: ${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }}
-      NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID: ${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }}
-      NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID: ${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }}
-      NEXT_PUBLIC_NOTION_SECRET_API_KEY: ${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }}
-      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-      NEXT_PUBLIC_KAKAO_REST_API_KEY: ${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }}
-      NEXT_PUBLIC_CDN_URL: ${{ secrets.NEXT_PUBLIC_CDN_URL }}
-      NEXT_PUBLIC_MOCK_SCORE_URL: ${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }}
-      NEXT_PUBLIC_MOCK_SCORE_API_KEY: ${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }}
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9.4.0
 
       - name: Install dependencies
         run: pnpm install
 
-      - name: All Package Build
+      - name: Create .env for build
         run: |
-          pnpm build
+          cat > .env << EOF
+          ${{ secrets.STAGE_ENV_FILE }}
+          EOF
+
+      - name: All Package Build
+        run: pnpm build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -53,20 +42,7 @@ jobs:
       - name: Docker Client build
         run: |
           docker build \
-          --build-arg NEXT_PUBLIC_STAGE=${{ secrets.NEXT_PUBLIC_STAGE }} \
-          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
-          --build-arg NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
-          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-          --build-arg NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF=${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }} \
-          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-          --build-arg NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }} \
-          --build-arg NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }} \
-          --build-arg NEXT_PUBLIC_NOTION_SECRET_API_KEY=${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }} \
-          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-          --build-arg NEXT_PUBLIC_KAKAO_REST_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }} \
-          --build-arg NEXT_PUBLIC_CDN_URL=${{ secrets.NEXT_PUBLIC_CDN_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./client.Dockerfile \
           -t ${{ secrets.AWS_ECR_STAGE_CLIENT_REPOSITORY }}:latest \
           .
@@ -74,12 +50,7 @@ jobs:
       - name: Docker Admin build
         run: |
           docker build \
-          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
-          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./admin.Dockerfile \
           -t ${{ secrets.AWS_ECR_STAGE_ADMIN_REPOSITORY }}:latest \
           .
@@ -110,36 +81,23 @@ jobs:
             docker rm hello-stage-client || true
             docker rm hello-stage-admin || true
 
+            cat > .env.stage << 'ENVEOF'
+            ${{ secrets.STAGE_ENV_FILE }}
+            ENVEOF
+
             docker run -d \
               --name hello-stage-client \
               -p 3004:3000 \
-              -e NEXT_PUBLIC_STAGE=${{ secrets.NEXT_PUBLIC_STAGE }} \
-              -e NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
-              -e NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
-              -e NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-              -e NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF=${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }} \
-              -e NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-              -e NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }} \
-              -e NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }} \
-              -e NEXT_PUBLIC_NOTION_SECRET_API_KEY=${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }} \
-              -e NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-              -e NEXT_PUBLIC_KAKAO_REST_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }} \
-              -e NEXT_PUBLIC_CDN_URL=${{ secrets.NEXT_PUBLIC_CDN_URL }} \
-              -e NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-              -e NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+              --env-file .env.stage \
               ${{ secrets.AWS_ECR_STAGE_CLIENT_REPOSITORY }}:latest
+
             docker run -d \
               --name hello-stage-admin \
               -p 3005:3000 \
-              -e NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
-              -e NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-              -e NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-              -e NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-              -e NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-              -e NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+              --env-file .env.stage \
               ${{ secrets.AWS_ECR_STAGE_ADMIN_REPOSITORY }}:latest
 
-             docker image prune -a -f
+            docker image prune -a -f
             EOF
 
       - name: Success Discord Notification

--- a/.github/workflows/stage-cd.yml
+++ b/.github/workflows/stage-cd.yml
@@ -2,7 +2,8 @@ name: hello-gsm-stage-cd
 
 on:
   push:
-    branches: develop
+    branches:
+    - develop
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stage-cd.yml
+++ b/.github/workflows/stage-cd.yml
@@ -100,24 +100,24 @@ jobs:
             docker image prune -a -f
             EOF
 
-      - name: Success Discord Notification
-        uses: sarisia/actions-status-discord@v1.11.0
-        if: success()
-        with:
-          webhook: ${{ secrets.WEBHOOK_URL }}
-          title: '✅ hello-gsm stage CD'
-          status: ${{ job.status }}
-          content: '배포가 성공적으로 완료되었습니다.'
-          username: hello-gsm bot
-          color: 4CAF50
-
-      - name: Failure notification to discord
-        uses: sarisia/actions-status-discord@v1.11.0
-        if: failure()
-        with:
-          webhook: ${{ secrets.WEBHOOK_URL }}
-          title: '❌ hello-gsm stage CD'
-          content: '배포 중 에러가 발생했습니다.'
-          status: ${{ job.status }}
-          username: hello-gsm bot
-          color: e74c3c
+#      - name: Success Discord Notification
+#        uses: sarisia/actions-status-discord@v1.11.0
+#        if: success()
+#        with:
+#          webhook: ${{ secrets.WEBHOOK_URL }}
+#          title: '✅ hello-gsm stage CD'
+#          status: ${{ job.status }}
+#          content: '배포가 성공적으로 완료되었습니다.'
+#          username: hello-gsm bot
+#          color: 4CAF50
+#
+#      - name: Failure notification to discord
+#        uses: sarisia/actions-status-discord@v1.11.0
+#        if: failure()
+#        with:
+#          webhook: ${{ secrets.WEBHOOK_URL }}
+#          title: '❌ hello-gsm stage CD'
+#          content: '배포 중 에러가 발생했습니다.'
+#          status: ${{ job.status }}
+#          username: hello-gsm bot
+#          color: e74c3c

--- a/.github/workflows/stage-cd.yml
+++ b/.github/workflows/stage-cd.yml
@@ -113,24 +113,24 @@ jobs:
             docker image prune -a -f
             EOF
 
-#      - name: Success Discord Notification
-#        uses: sarisia/actions-status-discord@v1.11.0
-#        if: success()
-#        with:
-#          webhook: ${{ secrets.WEBHOOK_URL }}
-#          title: '✅ hello-gsm stage CD'
-#          status: ${{ job.status }}
-#          content: '배포가 성공적으로 완료되었습니다.'
-#          username: hello-gsm bot
-#          color: 4CAF50
-#
-#      - name: Failure notification to discord
-#        uses: sarisia/actions-status-discord@v1.11.0
-#        if: failure()
-#        with:
-#          webhook: ${{ secrets.WEBHOOK_URL }}
-#          title: '❌ hello-gsm stage CD'
-#          content: '배포 중 에러가 발생했습니다.'
-#          status: ${{ job.status }}
-#          username: hello-gsm bot
-#          color: e74c3c
+      - name: Success Discord Notification
+        uses: sarisia/actions-status-discord@v1.11.0
+        if: success()
+        with:
+          webhook: ${{ secrets.WEBHOOK_URL }}
+          title: '✅ hello-gsm stage CD'
+          status: ${{ job.status }}
+          content: '배포가 성공적으로 완료되었습니다.'
+          username: hello-gsm bot
+          color: 4CAF50
+
+      - name: Failure notification to discord
+        uses: sarisia/actions-status-discord@v1.11.0
+        if: failure()
+        with:
+          webhook: ${{ secrets.WEBHOOK_URL }}
+          title: '❌ hello-gsm stage CD'
+          content: '배포 중 에러가 발생했습니다.'
+          status: ${{ job.status }}
+          username: hello-gsm bot
+          color: e74c3c

--- a/.github/workflows/stage-cd.yml
+++ b/.github/workflows/stage-cd.yml
@@ -21,14 +21,22 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Create .env for build
+      - name: Create .env files for build
         run: |
-          cat > .env << EOF
-          ${{ secrets.STAGE_ENV_FILE }}
+          cat > .env.client << EOF
+          ${{ secrets.STAGE_CLIENT_ENV_FILE }}
+          EOF
+          cat > .env.admin << EOF
+          ${{ secrets.STAGE_ADMIN_ENV_FILE }}
           EOF
 
       - name: All Package Build
-        run: pnpm build
+        run: |
+          # Client build with client env
+          cp .env.client apps/client/.env
+          # Admin build with admin env
+          cp .env.admin apps/admin/.env
+          pnpm build
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
@@ -43,7 +51,7 @@ jobs:
       - name: Docker Client build
         run: |
           docker build \
-          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
+          $(cat .env.client | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./client.Dockerfile \
           -t ${{ secrets.AWS_ECR_STAGE_CLIENT_REPOSITORY }}:latest \
           .
@@ -51,7 +59,7 @@ jobs:
       - name: Docker Admin build
         run: |
           docker build \
-          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
+          $(cat .env.admin | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./admin.Dockerfile \
           -t ${{ secrets.AWS_ECR_STAGE_ADMIN_REPOSITORY }}:latest \
           .
@@ -82,20 +90,24 @@ jobs:
             docker rm hello-stage-client || true
             docker rm hello-stage-admin || true
 
-            cat > .env.stage << 'ENVEOF'
-            ${{ secrets.STAGE_ENV_FILE }}
+            cat > .env.client.stage << 'ENVEOF'
+            ${{ secrets.STAGE_CLIENT_ENV_FILE }}
+            ENVEOF
+
+            cat > .env.admin.stage << 'ENVEOF'
+            ${{ secrets.STAGE_ADMIN_ENV_FILE }}
             ENVEOF
 
             docker run -d \
               --name hello-stage-client \
               -p 3004:3000 \
-              --env-file .env.stage \
+              --env-file .env.client.stage \
               ${{ secrets.AWS_ECR_STAGE_CLIENT_REPOSITORY }}:latest
 
             docker run -d \
               --name hello-stage-admin \
               -p 3005:3000 \
-              --env-file .env.stage \
+              --env-file .env.admin.stage \
               ${{ secrets.AWS_ECR_STAGE_ADMIN_REPOSITORY }}:latest
 
             docker image prune -a -f

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -21,19 +21,27 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Create .env for build
+      - name: Create .env files for build
         run: |
-          cat > .env << EOF
-          ${{ secrets.STAGE_ENV_FILE }}
+          cat > .env.client << EOF
+          ${{ secrets.STAGE_CLIENT_ENV_FILE }}
+          EOF
+          cat > .env.admin << EOF
+          ${{ secrets.STAGE_ADMIN_ENV_FILE }}
           EOF
 
       - name: All Package Build
-        run: pnpm build
+        run: |
+          # Client build with client env
+          cp .env.client apps/client/.env
+          # Admin build with admin env
+          cp .env.admin apps/admin/.env
+          pnpm build
 
       - name: Docker Client build
         run: |
           docker build \
-          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
+          $(cat .env.client | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./client.Dockerfile \
           -t hello-stage-client:latest \
           .
@@ -41,7 +49,7 @@ jobs:
       - name: Docker Admin build
         run: |
           docker build \
-          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
+          $(cat .env.admin | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./admin.Dockerfile \
           -t hello-stage-admin:latest \
           .

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -45,24 +45,24 @@ jobs:
           -t hello-stage-admin:latest \
           .
 
-      - name: Success Discord Notification
-        uses: sarisia/actions-status-discord@v1.11.0
-        if: success()
-        with:
-          webhook: ${{ secrets.WEBHOOK_URL }}
-          title: '✅ hello-gsm stage CI'
-          status: ${{ job.status }}
-          content: 'PR을 확인해주세요.'
-          username: hello-gsm bot
-          color: 4CAF50
-
-      - name: Failure notification to discord
-        uses: sarisia/actions-status-discord@v1.11.0
-        if: failure()
-        with:
-          webhook: ${{ secrets.WEBHOOK_URL }}
-          title: '❌ hello-gsm stage CI'
-          content: '에러를 확인해주세요.'
-          status: ${{ job.status }}
-          username: hello-gsm bot
-          color: e74c3c
+#      - name: Success Discord Notification
+#        uses: sarisia/actions-status-discord@v1.11.0
+#        if: success()
+#        with:
+#          webhook: ${{ secrets.WEBHOOK_URL }}
+#          title: '✅ hello-gsm stage CI'
+#          status: ${{ job.status }}
+#          content: 'PR을 확인해주세요.'
+#          username: hello-gsm bot
+#          color: 4CAF50
+#
+#      - name: Failure notification to discord
+#        uses: sarisia/actions-status-discord@v1.11.0
+#        if: failure()
+#        with:
+#          webhook: ${{ secrets.WEBHOOK_URL }}
+#          title: '❌ hello-gsm stage CI'
+#          content: '에러를 확인해주세요.'
+#          status: ${{ job.status }}
+#          username: hello-gsm bot
+#          color: e74c3c

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -54,24 +54,24 @@ jobs:
           -t hello-stage-admin:latest \
           .
 
-#      - name: Success Discord Notification
-#        uses: sarisia/actions-status-discord@v1.11.0
-#        if: success()
-#        with:
-#          webhook: ${{ secrets.WEBHOOK_URL }}
-#          title: '✅ hello-gsm stage CI'
-#          status: ${{ job.status }}
-#          content: 'PR을 확인해주세요.'
-#          username: hello-gsm bot
-#          color: 4CAF50
-#
-#      - name: Failure notification to discord
-#        uses: sarisia/actions-status-discord@v1.11.0
-#        if: failure()
-#        with:
-#          webhook: ${{ secrets.WEBHOOK_URL }}
-#          title: '❌ hello-gsm stage CI'
-#          content: '에러를 확인해주세요.'
-#          status: ${{ job.status }}
-#          username: hello-gsm bot
-#          color: e74c3c
+      - name: Success Discord Notification
+        uses: sarisia/actions-status-discord@v1.11.0
+        if: success()
+        with:
+          webhook: ${{ secrets.WEBHOOK_URL }}
+          title: '✅ hello-gsm stage CI'
+          status: ${{ job.status }}
+          content: 'PR을 확인해주세요.'
+          username: hello-gsm bot
+          color: 4CAF50
+
+      - name: Failure notification to discord
+        uses: sarisia/actions-status-discord@v1.11.0
+        if: failure()
+        with:
+          webhook: ${{ secrets.WEBHOOK_URL }}
+          title: '❌ hello-gsm stage CI'
+          content: '에러를 확인해주세요.'
+          status: ${{ job.status }}
+          username: hello-gsm bot
+          color: e74c3c

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -2,7 +2,8 @@ name: hello-gsm-stage-ci
 
 on:
   pull_request:
-    branches: develop
+    branches:
+    - develop
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -8,55 +8,31 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_STAGE: ${{ secrets.NEXT_PUBLIC_STAGE }}
-      NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }}
-      NEXT_PUBLIC_CHANNEL_IO_KEY: ${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }}
-      NEXT_PUBLIC_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_IMAGE_URL }}
-      NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF: ${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }}
-      NEXT_PUBLIC_NEIS_API_KEY: ${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }}
-      NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID: ${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }}
-      NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID: ${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }}
-      NEXT_PUBLIC_NOTION_SECRET_API_KEY: ${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }}
-      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-      NEXT_PUBLIC_KAKAO_REST_API_KEY: ${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }}
-      NEXT_PUBLIC_CDN_URL: ${{ secrets.NEXT_PUBLIC_CDN_URL }}
-      NEXT_PUBLIC_MOCK_SCORE_URL: ${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }}
-      NEXT_PUBLIC_MOCK_SCORE_API_KEY: ${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }}
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9.4.0
 
       - name: Install dependencies
         run: pnpm install
 
-      - name: All Package Build
+      - name: Create .env for build
         run: |
-          pnpm build
+          cat > .env << EOF
+          ${{ secrets.STAGE_ENV_FILE }}
+          EOF
+
+      - name: All Package Build
+        run: pnpm build
 
       - name: Docker Client build
         run: |
           docker build \
-          --build-arg NEXT_PUBLIC_STAGE=${{ secrets.NEXT_PUBLIC_STAGE }} \
-          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
-          --build-arg NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
-          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-          --build-arg NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF=${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }} \
-          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-          --build-arg NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }} \
-          --build-arg NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }} \
-          --build-arg NEXT_PUBLIC_NOTION_SECRET_API_KEY=${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }} \
-          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-          --build-arg NEXT_PUBLIC_KAKAO_REST_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }} \
-          --build-arg NEXT_PUBLIC_CDN_URL=${{ secrets.NEXT_PUBLIC_CDN_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./client.Dockerfile \
           -t hello-stage-client:latest \
           .
@@ -64,12 +40,7 @@ jobs:
       - name: Docker Admin build
         run: |
           docker build \
-          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
-          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
-          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
-          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
-          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
+          $(cat .env | sed 's/^/--build-arg /' | tr '\n' ' ') \
           -f ./admin.Dockerfile \
           -t hello-stage-admin:latest \
           .


### PR DESCRIPTION
## 개요💡

기존 HelloGSM FE의 CI/CD 파이프라인에서 환경변수를 `--build-arg`로 개별적으로 주입하는 방식을 사용하고 있었습니다. 환경변수 수가 증가함에 따라 이러한 방식은 관리 복잡성을 높이고 스크립트 가독성을 저해하는 문제가 발생했습니다. 이를 해결하기 위해 `env` secret을 활용한 통합 환경변수 주입 방식으로 개선하였습니다.

## 작업 내용

### 기존 방식
기존에는 각 환경변수를 개별적으로 `--build-arg`를 통해 주입하였습니다.

```shell
- name: Docker Client build
   run: |
          docker build \
          --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_PROD_API_BASE_URL }} \
          --build-arg NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
          --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
          --build-arg NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF=${{ secrets.NEXT_PUBLIC_SHOW_LOGIN_MODAL_FF }} \
          --build-arg NEXT_PUBLIC_NEIS_API_KEY=${{ secrets.NEXT_PUBLIC_NEIS_API_KEY }} \
          --build-arg NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_FAQ_DATABASE_ID }} \
          --build-arg NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID=${{ secrets.NEXT_PUBLIC_NOTION_MEMBER_DATABASE_ID }} \
          --build-arg NEXT_PUBLIC_NOTION_SECRET_API_KEY=${{ secrets.NEXT_PUBLIC_NOTION_SECRET_API_KEY }} \
          --build-arg NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }} \
          --build-arg NEXT_PUBLIC_KAKAO_REST_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_REST_API_KEY }} \
          --build-arg NEXT_PUBLIC_CDN_URL=${{ secrets.NEXT_PUBLIC_CDN_URL }} \
          --build-arg NEXT_PUBLIC_MOCK_SCORE_URL=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_URL }} \
          --build-arg NEXT_PUBLIC_MOCK_SCORE_API_KEY=${{ secrets.NEXT_PUBLIC_MOCK_SCORE_API_KEY }} \
          $(cat .env.client | sed 's/^/--build-arg /' | tr '\n' ' ') \
          -f ./client.Dockerfile \
          -t ${{ secrets.AWS_ECR_PROD_CLIENT_REPOSITORY }}:latest \
          .
```

### 개선된 방식
환경변수 파일을 활용한 통합 주입 방식으로 변경하였습니다.

```shell
- name: Docker Client build
   run: |
          docker build \
          $(cat .env.client | sed 's/^/--build-arg /' | tr '\n' ' ') \
          -f ./client.Dockerfile \
          -t ${{ secrets.AWS_ECR_STAGE_CLIENT_REPOSITORY }}:latest \
          .
```

## 환경변수 설정 방법

이번 개선으로 인해 Github Actions Secret 관리 방식이 변경되었습니다. 기존의 개별 변수 설정 대신 다음 4개의 통합 환경변수 파일을 설정하면 됩니다.

- `STAGE_CLIENT_ENV_FILE`
- `STAGE_ADMIN_ENV_FILE`
- `PROD_CLIENT_ENV_FILE`
- `PROD_ADMIN_ENV_FILE`

각 변수에는 [환경변수 관리 문서](https://www.notion.so/env-2753f7256185804a8199dfc4b03a5e73?source=copy_link)의 해당 내용을 설정하시면 됩니다.