### PR TITLE
fix: 1차 전형 메시지에서 '서류' 단어 제거

### DIFF
--- a/apps/client/src/components/PassResultDialog/index.tsx
+++ b/apps/client/src/components/PassResultDialog/index.tsx
@@ -35,8 +35,8 @@ const PassResultDialog = ({
     firstTestPassYes: {
       title: (
         <>
-          축하합니다! {userName} 님은 1차 서류 전형에{' '}
-          <span className={cn('text-sky-600')}>합격</span> 하셨습니다.
+          축하합니다! {userName} 님은 1차 전형에 <span className={cn('text-sky-600')}>합격</span>{' '}
+          하셨습니다.
         </>
       ),
       message: (
@@ -61,8 +61,7 @@ const PassResultDialog = ({
     firstTestPassNo: {
       title: (
         <>
-          {userName} 님은 1차 서류 전형에 <span className={cn('text-red-600')}>불합격</span>{' '}
-          하셨습니다.
+          {userName} 님은 1차 전형에 <span className={cn('text-red-600')}>불합격</span> 하셨습니다.
         </>
       ),
       message: (


### PR DESCRIPTION
## 개요 💡

> 선생님의 요청에 따라, 신입생 전형요강에 나와있는 문구와 일치시키기 위해 
`1차 서류 전형` → `1차 전형`으로 변경하였습니다.

[신입생 전형요강 6p 참고]
<img width="1010" height="449" alt="image" src="https://github.com/user-attachments/assets/05c66f48-44a9-4bdf-bda8-55aae26414c9" />

[참고 노션 바로 가기](https://www.notion.so/25-09-25-2793f72561858064b147f16cd18d4069?source=copy_link)
