### PR TITLE
Fix/exam guide and ticket text

### DIFF
--- a/apps/admin/src/pageContainer/TicketPage/index.tsx
+++ b/apps/admin/src/pageContainer/TicketPage/index.tsx
@@ -227,9 +227,13 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                     'font-normal',
                   )}
                 >
-                  (1) 입학등록동의서 1부 (11. 4.(월) 17시 마감) <br />
-                  (2) 건강진단서 1부 (11. 11.(월) 17시 마감) <br />
-                  토, 일요일 제외 / 마감시간 이전 도착분에 한하여 유효함.
+                  (1) 입학등록동의서 1부
+                  <br />
+                  (2) 건강진단서 1부
+                  <br />
+                  2025. 11. 05.(수)~ 11. 10.(월) 16:30
+                  <br />
+                  (※ 휴무일과 공휴일은 서류 접수하지 않음)
                 </td>
                 <td
                   rowSpan={2}
@@ -299,7 +303,7 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                 >
                   위 사람은 {NEXT_YEAR}학년도 <br /> 본교 신입생 입학전형 지원자임을 확인함.
                   <p className={cn('pr-[0.625rem]', 'text-center', 'font-normal')}>
-                    2024년 10월 25일
+                    2025년 10월 31일
                   </p>
                   <p>광주소프트웨어마이스터고등학교장 [직인생략]</p>
                 </td>

--- a/apps/admin/src/pageContainer/TicketPage/index.tsx
+++ b/apps/admin/src/pageContainer/TicketPage/index.tsx
@@ -86,7 +86,7 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                   {역량검사시험기간}
                 </td>
 
-                <td rowSpan={6} className={cn('h-[200px]', 'w-[150px]', 'border', 'border-black')}>
+                <td rowSpan={7} className={cn('h-[200px]', 'w-[150px]', 'border', 'border-black')}>
                   {ticket.profileImg && (
                     <img
                       src={ticket.profileImg}

--- a/packages/shared/src/constants/date.ts
+++ b/packages/shared/src/constants/date.ts
@@ -6,19 +6,19 @@ export const RECRUITMENT_PERIOD = {
 } as const;
 
 // TODO 정확한 날짜 확인 후 수정
-export const 역량검사일자 = '2024-07-25';
-export const 심층면접일자 = '2024-07-26';
-export const 역량검사시험기간 = '2024. 10. 25.(금) 13:00 ~ 16:10';
-export const 심층면접시험기간 = '2024. 10. 26.(토) 09:00 ~ 12:00';
+export const 역량검사일자 = '2025-10-31';
+export const 심층면접일자 = '2025-11-01';
+export const 역량검사시험기간 = '2025. 10. 31.(금) 14:00 ~ 16:30';
+export const 심층면접시험기간 = '2025. 11. 01.(토) 09:00 ~ 16:30';
 
 // TODO 정확한 날짜 확인 후 수정
 export const visionCampDate = {
-  startDate: '2025. 01. 15.(수)',
-  endDate: '2025. 01. 17.(금)',
+  startDate: '2026. 01. 14.(수)',
+  endDate: '2026. 01. 16.(금)',
 };
 
 // TODO 정확한 날짜 확인 후 수정
-export const passedMemberAnnounceDate = '2024. 10. 30.(수) 10:00';
+export const passedMemberAnnounceDate = '2025. 11. 05.(수) 10:00';
 export const passedMemberSubmitDate = {
   startDate: '2025. 11. 1.(수)',
   endDate: '2025. 11. 6.(월)',


### PR DESCRIPTION
## 개요 💡

> admin `PrintPage`에 일정이 작년 기준으로 되어있어 **올해 기준으로 변경하였습니다.**

## 작업내용 ⌨️

- 일정 업데이트
- 합격자 등록 및 서류 제출 텍스트 변경 

## 화면

<img width="978" height="451" alt="image" src="https://github.com/user-attachments/assets/20c4601e-1309-459a-bf73-ad90222a084f" />

[관련 노션 바로가기](https://www.notion.so/25-09-25-2793f72561858064b147f16cd18d4069?source=copy_link)