### PR TITLE
[feat] 주소 정식명칭 변환 기능 추가

### DIFF
--- a/packages/shared/src/components/register/Step1Register/index.tsx
+++ b/packages/shared/src/components/register/Step1Register/index.tsx
@@ -61,25 +61,30 @@ const Step1Register = ({
     { name: '여자', value: SexValueEnum.FEMALE },
   ];
 
+  const regionMap: Record<string, string> = {
+    서울: '서울특별시',
+    부산: '부산광역시',
+    대구: '대구광역시',
+    인천: '인천광역시',
+    광주: '광주광역시',
+    대전: '대전광역시',
+    울산: '울산광역시',
+    세종: '세종특별자치시',
+    경기: '경기도',
+    강원: '강원특별자치도',
+    충북: '충청북도',
+    충남: '충청남도',
+    전북: '전북특별자치도',
+    전남: '전라남도',
+    경북: '경상북도',
+    경남: '경상남도',
+    제주: '제주특별자치도',
+  };
+
   const handleDaumPostCodePopupComplete = ({ address }: Address) => {
-    const formattedAddress = address
-      .replace(/^서울\s/, '서울특별시 ')
-      .replace(/^부산\s/, '부산광역시 ')
-      .replace(/^대구\s/, '대구광역시 ')
-      .replace(/^인천\s/, '인천광역시 ')
-      .replace(/^광주\s/, '광주광역시 ')
-      .replace(/^대전\s/, '대전광역시 ')
-      .replace(/^울산\s/, '울산광역시 ')
-      .replace(/^세종\s/, '세종특별자치시 ')
-      .replace(/^경기\s/, '경기도 ')
-      .replace(/^강원\s/, '강원특별자치도 ')
-      .replace(/^충북\s/, '충청북도 ')
-      .replace(/^충남\s/, '충청남도 ')
-      .replace(/^전북\s/, '전북특별자치도 ')
-      .replace(/^전남\s/, '전라남도 ')
-      .replace(/^경북\s/, '경상북도 ')
-      .replace(/^경남\s/, '경상남도 ')
-      .replace(/^제주\s/, '제주특별자치도 ');
+    const [region, ...rest] = address.split(' ');
+    const formattedRegion = regionMap[region] ?? region;
+    const formattedAddress = [formattedRegion, ...rest].join(' ');
 
     setValue('address', formattedAddress, { shouldValidate: true, shouldDirty: true });
   };

--- a/packages/shared/src/components/register/Step1Register/index.tsx
+++ b/packages/shared/src/components/register/Step1Register/index.tsx
@@ -62,7 +62,26 @@ const Step1Register = ({
   ];
 
   const handleDaumPostCodePopupComplete = ({ address }: Address) => {
-    setValue('address', address, { shouldValidate: true, shouldDirty: true });
+    const formattedAddress = address
+      .replace(/^서울\s/, '서울특별시 ')
+      .replace(/^부산\s/, '부산광역시 ')
+      .replace(/^대구\s/, '대구광역시 ')
+      .replace(/^인천\s/, '인천광역시 ')
+      .replace(/^광주\s/, '광주광역시 ')
+      .replace(/^대전\s/, '대전광역시 ')
+      .replace(/^울산\s/, '울산광역시 ')
+      .replace(/^세종\s/, '세종특별자치시 ')
+      .replace(/^경기\s/, '경기도 ')
+      .replace(/^강원\s/, '강원특별자치도 ')
+      .replace(/^충북\s/, '충청북도 ')
+      .replace(/^충남\s/, '충청남도 ')
+      .replace(/^전북\s/, '전북특별자치도 ')
+      .replace(/^전남\s/, '전라남도 ')
+      .replace(/^경북\s/, '경상북도 ')
+      .replace(/^경남\s/, '경상남도 ')
+      .replace(/^제주\s/, '제주특별자치도 ');
+
+    setValue('address', formattedAddress, { shouldValidate: true, shouldDirty: true });
   };
 
   const handleZipCodeButtonClick = () =>


### PR DESCRIPTION
## 개요 💡
> 사용자가 집 주소 검색 시 "서울", "광주" 등 축약형 주소가 아닌 "서울특별시", "광주광역시" 등 정식명칭으로 표시되도록 개선했습니다.

## 배경
> 기존에는 "서울", "광주" 등 축약형이 표시되어 관리자가 수작업으로 "서울특별시", "광주광역시" 등으로 변경해야 했습니다. 이를 자동화하여 데이터 일관성과 관리 효율성을 높였습니다.
[지원자등록양식.xlsx](https://github.com/user-attachments/files/22551567/_20250909_101311.xlsx)

## 작업내용 ⌨️
- `handleDaumPostCodePopupComplete` 함수에 주소 변환 로직 추가
- 17개 시/도에 대한 정식명칭 매핑 처리
- 2024년 행정구역 개편 반영 (강원특별자치도, 전북특별자치도)
- 정규식 체인을 활용한 효율적인 문자열 변환 구현

## 화면
<img width="539" height="202" alt="image" src="https://github.com/user-attachments/assets/6edbffb4-a82d-4712-adb1-c3c360661a02" />
