### PR TITLE
[fix] 회원가입 페이지 유효성 검사 로직 개선

### DIFF
--- a/apps/client/src/pageContainer/SignUpPage/index.tsx
+++ b/apps/client/src/pageContainer/SignUpPage/index.tsx
@@ -119,7 +119,8 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
   const birthMonth = formMethods.watch('birth.month');
   const birthDay = formMethods.watch('birth.day');
 
-  const isCertificationButtonDisabled = !/^\d{10,11}$/.test(phoneNumber);
+  const isCertificationButtonDisabled =
+    !signupFormSchema.shape.phoneNumber.safeParse(phoneNumber).success;
   const isCertificationValid = isSuccess === true;
   const isSubmitButtonDisabled = !isCertificationValid || !isAgreed;
 
@@ -375,7 +376,7 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
                     variant="disabled"
                     className={cn('w-[5.25rem]')}
                     disabled={
-                      (isCertificationButtonDisabled || btnClick === true) && timeLeft !== 0
+                      isCertificationButtonDisabled || (btnClick === true && timeLeft !== 0)
                     }
                     onClick={() => {
                       sendCodeNumber(phoneNumber);

--- a/apps/client/src/schemas/signupForm.ts
+++ b/apps/client/src/schemas/signupForm.ts
@@ -13,7 +13,7 @@ const sexSchema = z.string().refine((value) => ['MALE', 'FEMALE'].includes(value
 
 const phoneNumberSchema = z
   .string()
-  .regex(/^\d{10,11}$/, { message: '번호 형식을 확인해 주세요.' })
+  .regex(/^010\d{8}$/, { message: '010으로 시작하는 11자리 번호를 입력해주세요.' })
   .min(1, { message: '전화번호를 입력해주세요.' });
 
 const birthSchema = z.object({


### PR DESCRIPTION
## 개요 💡

번호 인증 버튼의 비활성화 조건이 `(isCertificationButtonDisabled || btnClick === true) && timeLeft !== 0`으로 되어 있어, 전화번호를 입력하지 않아도 버튼이 활성화되는 문제가 있었습니다. 이를 `isCertificationButtonDisabled || (btnClick === true && timeLeft !== 0)`으로 수정하였고, `signupFormSchema`를 활용해 유효성 검사를 적용하여 스키마와 컴포넌트 간의 유효성 검사 로직을 일치시켰습니다.

## 작업내용 ⌨️

- 휴대폰 번호 유효성 검사 스키마 수정
- 번호 인증 버튼 비활성화 조건 변경
- 회원가입 스키마를 사용하여 유효성 검사 로직 통일