### PR TITLE
[fix] 인증번호 타이머 시작 시점 오류 수정

### DIFF
--- a/apps/client/src/pageContainer/SignUpPage/index.tsx
+++ b/apps/client/src/pageContainer/SignUpPage/index.tsx
@@ -84,8 +84,6 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
       const elapsedTime = Math.floor((Date.now() - parseInt(savedTime, 10)) / 1000);
       const remainingTime = initialTime - elapsedTime;
       setTimeLeft(remainingTime > 0 ? remainingTime : 0);
-    } else if (btnClick === true) {
-      sessionStorage.setItem('timerStart', Date.now().toString());
     }
 
     const interval = setInterval(() => {
@@ -93,7 +91,7 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [btnClick]);
+  }, []);
 
   useEffect(() => {
     if (timeLeft > 0) {
@@ -144,6 +142,8 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
       setBtnClick(true);
       setIsVerifyClicked(true);
       formMethods.setValue('isSentCertificationNumber', true);
+      setTimeLeft(180);
+      sessionStorage.setItem('timerStart', Date.now().toString());
     },
     onError: () => setVerificationCodeSendErrorModal(true),
   });
@@ -380,7 +380,6 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
                     }
                     onClick={() => {
                       sendCodeNumber(phoneNumber);
-                      setTimeLeft(180);
                     }}
                   >
                     {isVerifyClicked ? '재전송' : '번호 인증'}


### PR DESCRIPTION
## 개요 💡

이미 회원가입에 사용된 전화번호로 계정 생성을 시도할 경우, 번호 인증 버튼을 누르면 아래 사진과 같은 모달이 표시되었습니다.
하지만 확인/취소 버튼을 클릭하기도 전에 번호 인증 버튼을 누르는 순간 바로 타이머가 시작되는 문제가 있었습니다.
이를 수정하여 모달에서 '확인' 버튼을 눌렀을 때만 타이머가 시작되도록 변경했습니다.

<img width="517" height="168" alt="스크린샷 2025-09-29 오후 1 53 52" src="https://github.com/user-attachments/assets/417de968-6510-49f8-9607-224ba77b88e1" />  

## 작업내용 ⌨️

- 확인 버튼 클릭 시에만 인증 타이머 시작되도록 조건 변경