### PR TITLE
[revert] 보호자·담임 교사 전화번호 중복 허용

### DIFF
--- a/packages/shared/src/schemas/step3Schema.ts
+++ b/packages/shared/src/schemas/step3Schema.ts
@@ -18,8 +18,4 @@ export const step3Schema = z
     ({ relationshipWithGuardian, otherRelationshipWithGuardian }) =>
       relationshipWithGuardian !== RelationshipWithGuardianValueEnum.OTHER ||
       otherRelationshipWithGuardian,
-  )
-  .refine(
-    ({ guardianPhoneNumber, schoolTeacherPhoneNumber }) =>
-      !schoolTeacherPhoneNumber || guardianPhoneNumber !== schoolTeacherPhoneNumber,
   );


### PR DESCRIPTION
## 개요 💡

> 보호자와 담임교사 전화번호 중복 허용 작업했습니다.

## 개발 배경
> 최근 정책 재검토 결과 보호자와 담임교사가 동일한 경우도 허용 가능하다는 내용을 전달받았습니다. 
이에 따라 예전 PR [#253](https://github.com/themoment-team/hellogsm-front-25/pull/253)에서 적용한 중복 방지 로직을 제거하였습니다.

## 참고
[관련 디스코드](https://discord.com/channels/942787694872899604/991121731441930271/1422033728074420224)