### PR TITLE
[feat] 1, 2차 결과 발표 시 토스트 알림 추가

### DIFF
--- a/packages/shared/src/components/modal/AdminModals/index.tsx
+++ b/packages/shared/src/components/modal/AdminModals/index.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import type { AxiosError } from 'axios';
+
+import { toast } from 'react-toastify';
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -34,15 +38,25 @@ const AdminModals = () => {
   const { mutate: postFirstResult } = usePostFirstResult({
     onSuccess: () => {
       operationRefetch();
+      toast.success('1차 결과가 성공적으로 발표되었습니다!');
     },
-    onError: () => {},
+    onError: (error) => {
+      const axiosError = error as AxiosError<{ message?: string }>;
+      const serverMessage = axiosError.response?.data?.message;
+      toast.error(serverMessage ?? '1차 결과 발표 중 오류가 발생했습니다.');
+    },
   });
 
   const { mutate: postSecondResult } = usePostSecondResult({
     onSuccess: () => {
       operationRefetch();
+      toast.success('2차 결과가 성공적으로 발표되었습니다!');
     },
-    onError: () => {},
+    onError: (error) => {
+      const axiosError = error as AxiosError<{ message?: string }>;
+      const serverMessage = axiosError.response?.data?.message;
+      toast.error(serverMessage ?? '2차 결과 발표 중 오류가 발생했습니다.');
+    },
   });
 
   return (


### PR DESCRIPTION
## 개요 💡

어드민 페이지에서 1, 2차 결과 발표 시에 성공/실패 토스트 알림을 추가했습니다.

## 작업내용 ⌨️

- 1, 2차 결과 발표 시 토스트 알림 추가

## 관련 issue 🤯

테스트를 진행해보지 못 했습니다.