### PR TITLE
[feat] 회원가입 페이지 UI 개선

### DIFF
--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -417,7 +417,7 @@ const Header = ({ isServerHealthy }: HeaderProps) => {
       >
         <Logo isRegisterPath={isRegisterPath} />
 
-        <PCNavigation links={pcNavLinks} isRegisterPath={isRegisterPath} />
+        {!isLogin && <PCNavigation links={pcNavLinks} isRegisterPath={isRegisterPath} />}
 
         {/* PC width 일떄 */}
         {isServerHealthy && (
@@ -462,7 +462,7 @@ const Header = ({ isServerHealthy }: HeaderProps) => {
         </div>
       </header>
 
-      {isMenu && (
+      {isMenu && !isLogin && (
         <div
           className={cn(
             'flex',

--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -417,7 +417,7 @@ const Header = ({ isServerHealthy }: HeaderProps) => {
       >
         <Logo isRegisterPath={isRegisterPath} />
 
-        {!isLogin && <PCNavigation links={pcNavLinks} isRegisterPath={isRegisterPath} />}
+        <PCNavigation links={pcNavLinks} isRegisterPath={isRegisterPath} />
 
         {/* PC width 일떄 */}
         {isServerHealthy && (
@@ -462,7 +462,7 @@ const Header = ({ isServerHealthy }: HeaderProps) => {
         </div>
       </header>
 
-      {isMenu && !isLogin && (
+      {isMenu && (
         <div
           className={cn(
             'flex',

--- a/apps/client/src/pageContainer/SignUpPage/index.tsx
+++ b/apps/client/src/pageContainer/SignUpPage/index.tsx
@@ -28,6 +28,10 @@ import {
   SelectContent,
   SelectValue,
   SelectItem,
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  LoginDialogContent,
 } from 'shared/components';
 import { CURRENT_YEAR } from 'shared/constants';
 import { useDebounce } from 'shared/hooks';
@@ -466,6 +470,18 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
             >
               회원가입 완료
             </Button>
+            <p className={cn('text-sm', 'font-normal', 'text-gray-600', 'text-end')}>
+              <Dialog>
+                <DialogTrigger asChild>
+                  <button type="button" className={cn('underline', 'cursor-pointer')}>
+                    다른 계정으로 로그인하기
+                  </button>
+                </DialogTrigger>
+                <DialogContent className={cn('w-fit', 'p-0', '!rounded-[20px]')}>
+                  <LoginDialogContent />
+                </DialogContent>
+              </Dialog>
+            </p>
           </form>
         </FormProvider>
       </main>

--- a/packages/shared/src/components/LoginDialog/index.tsx
+++ b/packages/shared/src/components/LoginDialog/index.tsx
@@ -1,5 +1,5 @@
 import * as I from 'shared/assets';
-import { Button, LoginButton } from 'shared/components';
+import { Button, LoginDialogContent } from 'shared/components';
 import { Dialog, DialogContent, DialogTrigger } from 'shared/components';
 import { cn } from 'shared/lib/utils';
 
@@ -32,25 +32,7 @@ const LoginDialog = ({ variant = 'pc' }: LoginDialogProps) => {
         )}
       </DialogTrigger>
       <DialogContent className={cn('w-fit', 'p-0', '!rounded-[20px]')}>
-        <div
-          className={cn(
-            'w-fit',
-            'flex',
-            'pt-8',
-            'px-12',
-            'pb-10',
-            'flex-col',
-            'items-center',
-            'gap-8',
-          )}
-        >
-          {/* <h1>현재는 로그인을 할 수 없습니다.</h1> */}
-          <span className={cn('text-2xl', 'font-semibold', 'text-gray-900')}>로그인</span>
-          <div className={cn('flex', 'flex-col', 'gap-3')}>
-            <LoginButton variant="kakao">카카오로 시작하기</LoginButton>
-            <LoginButton variant="google">Google 계정으로 시작하기</LoginButton>
-          </div>
-        </div>
+        <LoginDialogContent />
       </DialogContent>
     </Dialog>
   );

--- a/packages/shared/src/components/LoginDialogContent/index.tsx
+++ b/packages/shared/src/components/LoginDialogContent/index.tsx
@@ -1,0 +1,18 @@
+import { LoginButton } from 'shared/components';
+import { cn } from 'shared/lib/utils';
+
+const LoginDialogContent = () => {
+  return (
+    <div
+      className={cn('w-fit', 'flex', 'pt-8', 'px-12', 'pb-10', 'flex-col', 'items-center', 'gap-8')}
+    >
+      <span className={cn('text-2xl', 'font-semibold', 'text-gray-900')}>로그인</span>
+      <div className={cn('flex', 'flex-col', 'gap-3')}>
+        <LoginButton variant="kakao">카카오로 시작하기</LoginButton>
+        <LoginButton variant="google">Google 계정으로 시작하기</LoginButton>
+      </div>
+    </div>
+  );
+};
+
+export default LoginDialogContent;

--- a/packages/shared/src/components/index.ts
+++ b/packages/shared/src/components/index.ts
@@ -18,5 +18,6 @@ export { default as Step2Register } from './register/Step2Register';
 export { default as Step3Register } from './register/Step3Register';
 export { default as Step4Register } from './register/Step4Register';
 export { default as LoginDialog } from './LoginDialog';
+export { default as LoginDialogContent } from './LoginDialogContent';
 export { default as ModalContainer } from './ModalContainer';
 export * from './modal';


### PR DESCRIPTION
## 개요 💡

> 회원가입 페이지에 다른 계정으로 로그인하기 기능 추가했습니다

## 개발 배경
기존엔 회원가입 중 사용자가 실수로 다른 계정을 선택하는 경우에 대한 처리가 없었습니다.
따라서 회원가입 페이지에 **다른 계정으로 로그인하기 기능**을 추가했습니다.

## 작업내용 ⌨️
1. **[SignUpPage] 다른 계정으로 로그인하기 기능 추가** → 사용자 편의성 향상
2. **[LoginDialog] `LoginDialogContent` 컴포넌트로 분리** → 모달 내부 로직을 별도 컴포넌트로 분리하여 가독성 및 재사용성 개선

### 기타
> 리팩터링과 기능 추가가 함께 포함되어 있으니 리뷰 시 참고 부탁드립니다 🙇‍♀️
