### PR TITLE
[fix] 번호 인증 타이머 만료 시 휴대폰 번호 재입력 허용

### DIFF
--- a/apps/client/src/pageContainer/SignUpPage/index.tsx
+++ b/apps/client/src/pageContainer/SignUpPage/index.tsx
@@ -375,7 +375,7 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
                     <Input
                       {...formMethods.register('phoneNumber')}
                       placeholder="번호 입력 (하이픈 '-' 제외)"
-                      disabled={isSentCertificationNumber}
+                      disabled={isSentCertificationNumber && timeLeft > 0}
                     />
                   </div>
                   {btnClick === true && (


### PR DESCRIPTION
## 개요 💡

번호 인증 시 3분 타이머가 종료된 후에도 전화번호 입력란이 비활성화된 문제가 있었는데, 타이머 만료 시 사용자가 휴대폰 번호를 다시 입력할 수 있도록 수정했습니다.

## 작업내용 ⌨️

번호 인증 타이머 만료 시 휴대폰 번호 재입력 허용