### PR TITLE
[fix] 지원자 목록 테이블 표시 정보 수정

### DIFF
--- a/apps/admin/src/components/ApplicantTH/index.tsx
+++ b/apps/admin/src/components/ApplicantTH/index.tsx
@@ -48,7 +48,7 @@ const ApplicantTH = () => {
                 </div>
               </div>
             </TableCell>
-            <TableCell className={cn([defaultStyle, 'w-[7rem]'])}>지원자 정보</TableCell>
+            <TableCell className={cn([defaultStyle, 'w-[7rem]'])}>성명</TableCell>
             <TableCell className={cn([defaultStyle, 'w-[7.5rem]'])}>수험 번호</TableCell>
             <TableCell className={cn([defaultStyle, 'w-[8.5rem]'])}>출신 중학교</TableCell>
             <TableCell className={cn([defaultStyle, 'w-[6.75rem]'])}>전형</TableCell>

--- a/apps/admin/src/components/ApplicantTR/index.tsx
+++ b/apps/admin/src/components/ApplicantTR/index.tsx
@@ -43,7 +43,6 @@ const ApplicantTR = ({
   interviewScore,
   memberId,
   name,
-  phoneNumber,
   realOneseoArrivedYn,
   schoolName,
   screening,

--- a/apps/admin/src/components/ApplicantTR/index.tsx
+++ b/apps/admin/src/components/ApplicantTR/index.tsx
@@ -182,8 +182,7 @@ const ApplicantTR = ({
             </Toggle>
           </TableCell>
           <TableCell className={cn('w-[7.5rem]', 'font-semibold', 'text-zinc-900')}>
-            {name} <br />
-            <span className={cn('font-normal', 'text-zinc-600')}>{phoneNumber}</span>
+            {name}
           </TableCell>
           <TableCell className={cn('w-[8rem]', 'text-zinc-900')}>
             {examinationNumber === null ? <Badge variant={'미정'}>미정</Badge> : examinationNumber}


### PR DESCRIPTION
## 개요 💡

선생님 요구사항에 따라 컬럼명을 '지원자 정보'에서 '성명'으로 변경하고, 이름만 표시되도록 수정했습니다.

## 작업내용 ⌨️

- 컬럼명을 '지원자 정보' -> '성명'으로 변경
- 전화번호는 제외하고 이름만 표시되도록 수정
