### PR TITLE
[feat] admin edit bar에 register-error 로직 추가

### DIFF
--- a/packages/shared/src/components/EditBar/index.tsx
+++ b/packages/shared/src/components/EditBar/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { StepEnum } from 'types';
 
 import { EditCheckIcon } from 'shared/assets';
 import { Button } from 'shared/index';
@@ -10,10 +11,20 @@ interface EditBarProps {
   isStep4: boolean;
   isStep4Success: boolean;
   handleOneseoEditButtonClick: () => void;
+  handleStepError: (step: StepEnum) => void;
 }
 
-const EditBar = ({ isStep4, isStep4Success, handleOneseoEditButtonClick }: EditBarProps) => {
+const EditBar = ({
+  isStep4,
+  isStep4Success,
+  handleOneseoEditButtonClick,
+  handleStepError,
+}: EditBarProps) => {
   const { push } = useRouter();
+
+  const handleCheckErrorStepFour = () => {
+    handleStepError(StepEnum.FOUR);
+  };
 
   return (
     <div
@@ -36,9 +47,9 @@ const EditBar = ({ isStep4, isStep4Success, handleOneseoEditButtonClick }: EditB
         홈으로
       </Button>
       {isStep4 && (
-        <button
-          disabled={!isStep4Success}
-          onClick={handleOneseoEditButtonClick}
+        <Button
+          variant={!isStep4Success ? 'submit' : 'fill'}
+          onClick={!isStep4Success ? handleCheckErrorStepFour : handleOneseoEditButtonClick}
           className={cn(
             'px-4',
             'py-2',
@@ -48,8 +59,6 @@ const EditBar = ({ isStep4, isStep4Success, handleOneseoEditButtonClick }: EditB
             'font-normal',
             'font-semibold',
             'leading-3',
-            'bg-blue-600',
-            'text-white',
             'rounded-md',
             'items-center',
             'h-10',
@@ -57,7 +66,7 @@ const EditBar = ({ isStep4, isStep4Success, handleOneseoEditButtonClick }: EditB
         >
           <EditCheckIcon />
           원서 수정 완료
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/packages/shared/src/components/StepWrapper/index.tsx
+++ b/packages/shared/src/components/StepWrapper/index.tsx
@@ -472,6 +472,7 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
           isStep4={isStep4}
           isStep4Success={isStepSuccess[4]}
           handleOneseoEditButtonClick={handleOneseoEditButtonClick}
+          handleStepError={handleStepError}
         />
       )}
     </>


### PR DESCRIPTION
## 개요 💡

admin 수정페이지에서 하단에 edit bar에 register-error로직을 추가했습니다

## 작업내용 ⌨️

error

<img width="884" height="373" alt="스크린샷 2025-10-02 121134" src="https://github.com/user-attachments/assets/3e19d244-045a-4838-9f1b-67c78235d81f" />

success

<img width="804" height="346" alt="image" src="https://github.com/user-attachments/assets/1af4ac8a-5fd6-4488-b6dc-593846d8fce3" />


